### PR TITLE
fixes an issue with flow actions and multiple devices

### DIFF
--- a/drivers/mill/device.js
+++ b/drivers/mill/device.js
@@ -39,8 +39,8 @@ class MillDevice extends Homey.Device {
     this.setProgramAction
       .register()
       .registerRunListener((args) => {
-        debug(`[${this.getName()}] Flow changed mode to ${args.mill_mode}`);
-        return this.setThermostatMode(args.mill_mode);
+        debug(`[${args.device.getName()}] Flow changed mode to ${args.mill_mode}`);
+        return args.device.setThermostatMode(args.mill_mode);
       });
 
     this.refreshTimeout = null;


### PR DESCRIPTION
Issue: 

If you have more than one device and try to change the mode on both of them through a flow, only one of them will get the new mode. 

I have two devices, mill1 and mill2. 

Log output prior to this fix: 

```
2020-01-01 12:20:56 [log] [MillApp] DEBUG: [mill1] Flow changed mode to Sleep
2020-01-01 12:20:56 [log] [MillApp] DEBUG: [mill1] Flow changed mode to Sleep
```
Only mill1 is changed to mode Sleep, mill2 is unchanged.

After this fix: 
```
2020-01-01 12:51:01 [log] [MillApp] DEBUG: [mill1] Flow changed mode to Sleep
2020-01-01 12:51:01 [log] [MillApp] DEBUG: [mill2] Flow changed mode to Sleep
```

This fix issue #12 and multiple other reports in the homey forum. 

